### PR TITLE
gcc13 requires include `<cstdint>` for `uint64_t`

### DIFF
--- a/testlib.h
+++ b/testlib.h
@@ -177,6 +177,7 @@ const char *latestFeatures[] = {
 #include <limits>
 #include <stdarg.h>
 #include <fcntl.h>
+#include <cstdint>
 
 #if (_WIN32 || __WIN32__ || _WIN64 || __WIN64__ || __CYGWIN__)
 #   if !defined(_MSC_VER) || _MSC_VER > 1400


### PR DESCRIPTION
Ported from https://github.com/MikeMirzayanov/testlib/commit/3c6e5c675bf6275b3c8b2935feb2d965e889c380